### PR TITLE
Restore selection metadata table and add metadata sidebar tab

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -541,8 +541,15 @@ dashboardPage(dark = T,
                                   ),
                                   sidebar = boxSidebar(
                                       id = "mycardsidebar",
-                                      fluidRow(style = "padding:1rem; overflow-x: scroll",
-                                               DT::dataTableOutput("event"))
+                                      tabsetPanel(
+                                          id = "sidebar_tables",
+                                          tabPanel("Library Matches",
+                                                   fluidRow(style = "padding:1rem; overflow-x: scroll",
+                                                            DT::dataTableOutput("event"))),
+                                          tabPanel("Uploaded Metadata",
+                                                   fluidRow(style = "padding:1rem; overflow-x: scroll",
+                                                            DT::dataTableOutput("sidebar_metadata")))
+                                      )
                                   )
                               )
                           ),


### PR DESCRIPTION
## Summary
- Show active spectrum and selected library metadata beneath plot
- Add sidebar tabs for library matches and uploaded metadata
- Link sidebar metadata selection to heatmap

## Testing
- ⚠️ `R -q -e "lintr::lint_dir()"` *(failed: package 'lintr' unavailable due to repository access)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1211d0f483208d17b22cd0f14918