### PR TITLE
Handle sidebar selection events safely

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -536,7 +536,7 @@ dashboardPage(dark = T,
                                   ),
                                   plotlyOutput("MyPlotC", inline = TRUE),
                                   div(style = "overflow-x: scroll",
-                                      DT::dataTableOutput("eventmetadata"),
+                                      DT::dataTableOutput("sidebar_metadata"),
                                       uiOutput("meta_toggle")
                                   ),
                                   sidebar = boxSidebar(


### PR DESCRIPTION
## Summary
- add `suppress_sidebar` reactive flag and use it to ignore programmatic sidebar row changes
- sync sidebar metadata table selection with plot selection and throttle arrow navigation

## Testing
- `apt-get install -y r-base`
- `R -q -e 'if (!requireNamespace("lintr", quietly = TRUE)) install.packages("lintr", repos="https://cloud.r-project.org"); lintr::lint("server.R"); lintr::lint("ui.R")'` *(fails: package 'lintr' is not available for this version of R)*

------
https://chatgpt.com/codex/tasks/task_e_68ae303db94c8320a1405349bd3ed77b