### PR TITLE
Add shareable settings link

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -184,14 +184,21 @@ dashboardPage(dark = T,
                        )
               ),
               #Analyze Spectra Tab ----
-              tabItem("analyze", 
+              tabItem("analyze",
                       br(),
-                       fluidRow(
-                           column(2,
+                      fluidRow(
+                          column(10,
+                                 textInput("settings_link", "Shareable link", width = "100%")),
+                          column(2,
+                                 actionButton("copy_link", "Copy link", style = "margin-top: 25px; width: 100%;"))
+                      ),
+                      br(),
+                      fluidRow(
+                          column(2,
                                   ##Upload/download ----
                                   #tags$label("Upload File"),
                                   fluidRow(style = "display: flex; align-items: flex-end;",
-                                      column(12, 
+                                      column(12,
                                              fileInput("file", NULL, multiple = T,
                                                        placeholder = ".csv, .zip, .asp, .jdx, .spc, .spa, .0",
                                                        accept=c("text/csv",


### PR DESCRIPTION
## Summary
- Restore inputs from URL query string on load
- Generate a shareable link that reflects current settings and updates browser URL
- Add UI control and copy button for easy sharing of settings

## Testing
- `R -q -e "lintr::lint('server.R')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c20f434774832091a4135ab637f900