### PR TITLE
Display app metadata version info in header

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -23,10 +23,10 @@ dashboardPage(dark = T,
                 class = "dropdown",
                 style = "list-style-type: none;",
                 tags$a(
-                    paste0("Last Updated: ",Sys.Date()),
-                    href = "https://github.com/Moore-Institute-4-Plastic-Pollution-Res/openspecy?tab=readme-ov-file#version-history",
+                    app_version_display$text,
+                    href = app_version_display$href,
                     target = "_blank",
-                    title = "Click here to view older versions of this app",
+                    title = app_version_display$title,
                     style = "font-size: 19px;text-decoration: none;"
                      )
                 )


### PR DESCRIPTION
## Summary
- read the downloaded app metadata file and derive a descriptive version display with commit, ref, and download date details
- replace the header's static last-updated text with the metadata-driven version information while falling back to the previous link when metadata is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3de6aafcc8320a6014fc83fb1716a